### PR TITLE
Drop proxy support for now

### DIFF
--- a/lib/peer.js
+++ b/lib/peer.js
@@ -3,7 +3,6 @@
 var Buffers = require('./buffers');
 var EventEmitter = require('events').EventEmitter;
 var Net = require('net');
-var Socks5Client = require('socks5-client');
 var bitcore = require('@exodus/bitcore-lib');
 var Networks = bitcore.Networks;
 var Messages = require('./messages');
@@ -124,13 +123,7 @@ Peer.STATUS = {
  * @returns {Peer} The same Peer instance.
  */
 Peer.prototype.setProxy = function(host, port) {
-  $.checkState(this.status === Peer.STATUS.DISCONNECTED);
-
-  this.proxy = {
-    host: host,
-    port: port
-  };
-  return this;
+  throw new Error('Setting a proxy is not supported in bitcore-p2p fork')
 };
 
 /**
@@ -237,10 +230,6 @@ Peer.prototype._readMessage = function() {
  * @returns {Socket} A Socket instance not yet connected.
  */
 Peer.prototype._getSocket = function() {
-  if (this.proxy) {
-    return new Socks5Client(this.proxy.host, this.proxy.port);
-  }
-
   return new Net.Socket();
 };
 

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
   "dependencies": {
     "@exodus/bitcore-lib": "^0.13.19",
     "bloom-filter": "^0.2.0",
-    "buffers": "bitpay/node-buffers#v0.1.2-bitpay",
-    "socks5-client": "^0.3.6"
+    "buffers": "bitpay/node-buffers#v0.1.2-bitpay"
   },
   "devDependencies": {
     "bitcore-build": "git://github.com/bitpay/bitcore-build.git",

--- a/test/peer.js
+++ b/test/peer.js
@@ -106,23 +106,6 @@ describe('Peer', function() {
     peer.port.should.equal(8111);
   });
 
-  it('set a proxy', function() {
-    var peer, peer2, socket;
-
-    peer = new Peer('localhost');
-    expect(peer.proxy).to.be.undefined();
-    socket = peer._getSocket();
-    socket.should.be.instanceof(Net.Socket);
-
-    peer2 = peer.setProxy('127.0.0.1', 9050);
-    peer2.proxy.host.should.equal('127.0.0.1');
-    peer2.proxy.port.should.equal(9050);
-    socket = peer2._getSocket();
-    socket.should.be.instanceof(Socks5Client);
-
-    peer.should.equal(peer2);
-  });
-
   it('send pong on ping', function(done) {
     var peer = new Peer({host: 'localhost'});
     var pingMessage = messages.Ping();


### PR DESCRIPTION
It's unused afaik, and it pulls in a really old version of `socks5-client`.

An alternative would be to update `socks5-client` dep version to latest, but I don't believe we really need it atm?

`socks5-client@0.3.6` pulls in 25 additional deps.

`socks5-client@1.2.8` pulls in 4 additional deps.